### PR TITLE
Fix bug caused by unrounded BigDecimals

### DIFF
--- a/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
+++ b/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
@@ -84,9 +84,9 @@ public class YNABHandler {
         try {
             SaveTransaction transaction = new SaveTransaction();
             transaction.setAccountId(this.accountUUID);
-            BigDecimal converted_amount = new BigDecimal(amount * 1000);
-            converted_amount = converted_amount.setScale(0, RoundingMode.HALF_UP);
-            transaction.setAmount(converted_amount);
+            BigDecimal converted_amount = ;
+            converted_amount = converted_amount;
+            transaction.setAmount((new BigDecimal(amount * 1000)).setScale(0, RoundingMode.HALF_UP));
             transaction.setApproved(false);
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
             transaction.setDate(LocalDate.parse(dateFormat.format(date)));

--- a/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
+++ b/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
@@ -84,8 +84,6 @@ public class YNABHandler {
         try {
             SaveTransaction transaction = new SaveTransaction();
             transaction.setAccountId(this.accountUUID);
-            BigDecimal converted_amount = ;
-            converted_amount = converted_amount;
             transaction.setAmount((new BigDecimal(amount * 1000)).setScale(0, RoundingMode.HALF_UP));
             transaction.setApproved(false);
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");

--- a/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
+++ b/src/main/java/com/github/gclfames5/ynab/YNABHandler.java
@@ -14,6 +14,7 @@ import ynab.client.invoker.auth.ApiKeyAuth;
 import ynab.client.model.*;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -83,7 +84,9 @@ public class YNABHandler {
         try {
             SaveTransaction transaction = new SaveTransaction();
             transaction.setAccountId(this.accountUUID);
-            transaction.setAmount(new BigDecimal(amount * 1000));
+            BigDecimal converted_amount = new BigDecimal(amount * 1000);
+            converted_amount = converted_amount.setScale(0, RoundingMode.HALF_UP);
+            transaction.setAmount(converted_amount);
             transaction.setApproved(false);
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
             transaction.setDate(LocalDate.parse(dateFormat.format(date)));


### PR DESCRIPTION
BigDecimal can have unpredictable results when being initialized with doubles/floats ([context](https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#BigDecimal-double-)), but trying to convert amount to string before applying BigDecimal resulted in a scale > 0 which was also causing errors. So this is a workaround for that. Related issue: https://github.com/gcflames5/ynab-splitwise-integration/issues/14